### PR TITLE
implement lex sort

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,19 +5,18 @@ authors = ["Neville Dipale <nevilledips@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-arrow = { git = "https://github.com/apache/arrow"}
-# arrow = { path = "../../arrow/rust/arrow"}
-parquet = { git = "https://github.com/apache/arrow" }
+arrow = { git = "https://github.com/nevi-me/arrow", branch = "concat-support" }
+parquet = { git = "https://github.com/nevi-me/arrow", branch = "concat-support" }
 num = "0.2"
 num-traits = "0.2"
 csv = "1"
 byteorder = "1"
 flatbuffers = "0.6"
 array_tool = "1"
-postgres = {version = "0.17.0", features = ["with-chrono-0_4", "with-uuid-0_8"]}
+postgres = {version = "0.17.3", features = ["with-chrono-0_4", "with-uuid-0_8"]}
 chrono = "0.4"
 # for lazy evaluation
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 # for parallel execution
-rayon = "1.0"
+rayon = "1.3"

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -25,6 +25,8 @@ use crate::io::sql::{self, SqlDataSink, SqlDataSource};
 use crate::table::Column;
 use crate::utils;
 
+use compute::{SortColumn, SortOptions};
+
 pub struct DataFrame {
     schema: Arc<Schema>,
     columns: Vec<Column>,
@@ -189,16 +191,24 @@ impl DataFrame {
     ///
     /// Note that the signature will be changed to return `Self` if all Arrow types can be sortable
     pub fn sort(&self, criteria: &Vec<SortCriteria>) -> Result<Self> {
-        if criteria.len() != 1 {
+        if criteria.is_empty() {
             return Err(DataFrameError::ComputeError(
-                "Sorting currently supports 1 sort criterion".to_string(),
+                "Sort criteria cannot be empty".to_string(),
             ));
         }
-        let options = criteria.first().unwrap();
-        let column = self.column_by_name(options.column.as_ref());
-        let array = column.to_array()?;
-        let sort_indices =
-            compute::kernels::sort::sort_to_indices(&array, Some(options.to_arrow_sort_options()))?;
+        let mut lex_criteria = vec![];
+        for c in criteria {
+            let column = self.column_by_name(c.column.as_ref());
+            let array = column.to_array()?;
+            lex_criteria.push(SortColumn {
+                values: array,
+                options: Some(SortOptions {
+                    descending: c.descending,
+                    nulls_first: false,
+                }),
+            });
+        }
+        let sort_indices = compute::kernels::sort::lexsort_to_indices(&lex_criteria)?;
         self.sort_by_indices(&sort_indices)
     }
 
@@ -812,30 +822,40 @@ mod tests {
             Field::new("a", DataType::Int32, true),
             Field::new("b", DataType::UInt8, false),
         ]);
-        let a = Int32Array::from(vec![Some(1), None, Some(3), Some(4)]);
-        let b = UInt8Array::from(vec![5, 6, 7, 8]);
+        let a = Int32Array::from(vec![Some(1), Some(1), None, Some(3), Some(3), Some(4)]);
+        let b = UInt8Array::from(vec![9, 5, 6, 7, 4, 8]);
         let frame = DataFrame::from_arrays(Arc::new(schema), vec![Arc::new(a), Arc::new(b)]);
-        let sort_criteria = SortCriteria {
+        let sort_criteria_a = SortCriteria {
             column: "a".to_string(),
             descending: true,
+            nulls_first: false,
         };
-        let sorted = frame.sort(&vec![sort_criteria]).unwrap();
+        let sort_criteria_b = SortCriteria {
+            column: "b".to_string(),
+            descending: false,
+            nulls_first: false,
+        };
+        let sorted = frame.sort(&vec![sort_criteria_a, sort_criteria_b]).unwrap();
         let a = sorted.column(0);
         let a_chunks = a.data().chunks();
         assert_eq!(a_chunks.len(), 1);
         let a_array = a_chunks[0].as_any().downcast_ref::<Int32Array>().unwrap();
-        assert!(a_array.is_null(3));
+        assert!(a_array.is_null(5));
         assert_eq!(a_array.value(0), 4);
         assert_eq!(a_array.value(1), 3);
-        assert_eq!(a_array.value(2), 1);
+        assert_eq!(a_array.value(2), 3);
+        assert_eq!(a_array.value(3), 1);
+        assert_eq!(a_array.value(4), 1);
 
         let b = sorted.column(1);
         let b_chunks = b.data().chunks();
         assert_eq!(b_chunks.len(), 1);
         let b_array = b_chunks[0].as_any().downcast_ref::<UInt8Array>().unwrap();
         assert_eq!(b_array.value(0), 8);
-        assert_eq!(b_array.value(1), 7);
-        assert_eq!(b_array.value(2), 5);
-        assert_eq!(b_array.value(3), 6);
+        assert_eq!(b_array.value(1), 4);
+        assert_eq!(b_array.value(2), 7);
+        assert_eq!(b_array.value(3), 5);
+        assert_eq!(b_array.value(4), 9);
+        assert_eq!(b_array.value(5), 6);
     }
 }

--- a/src/evaluation.rs
+++ b/src/evaluation.rs
@@ -85,7 +85,7 @@ impl Evaluate for DataFrame {
                     Read(reader) => Self::read(&reader),
                     Filter(cond) => frame.filter(cond),
                     Limit(size) => frame.limit(*size),
-                    Sort(criteria) => frame.sort(criteria),
+                    Sort(criteria) => frame.sort(criteria).expect("Unable to sort dataframe"),
                 };
             }
         }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -308,6 +308,7 @@ pub enum Transformation {
 pub struct SortCriteria {
     pub column: String,
     pub descending: bool,
+    pub nulls_first: bool,
 }
 
 impl SortCriteria {

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -4,7 +4,7 @@ use crate::error::DataFrameError;
 use crate::io::datasource::DataSourceEval;
 
 use arrow::datatypes::DataType;
-use arrow::error::ArrowError;
+use arrow::{compute::kernels::sort::SortOptions, error::ArrowError};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -308,6 +308,15 @@ pub enum Transformation {
 pub struct SortCriteria {
     pub column: String,
     pub descending: bool,
+}
+
+impl SortCriteria {
+    pub fn to_arrow_sort_options(&self) -> SortOptions {
+        SortOptions {
+            descending: self.descending,
+            nulls_first: false,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/table.rs
+++ b/src/table.rs
@@ -139,21 +139,13 @@ where
 {
     let len = column.num_rows();
     let mut builder = PrimitiveBuilder::<T>::new(len);
-    let arrays = col_to_prim_arrays::<T>(column);
-    for array in arrays {
-        if array.null_count() == 0 {
-            builder.append_slice(array.value_slice(array.offset(), array.len()))?;
-        } else {
-            builder.append_values(
-                array.value_slice(0, array.len()),
-                array
-                    .data()
-                    .null_buffer()
-                    .expect("Array has nulls but no null buffer")
-                    .data(),
-            )?;
-        }
-    }
+    let arrays = column
+        .data()
+        .chunks()
+        .into_iter()
+        .map(|array| array.data())
+        .collect::<Vec<ArrayDataRef>>();
+    builder.append_data(&arrays[..])?;
     Ok(Arc::new(builder.finish()))
 }
 
@@ -261,27 +253,26 @@ impl Column {
                 return Err(DataFrameError::ComputeError(
                     "Not yet implemented".to_string(),
                 ))
-            }
-            t => {
-                return Err(DataFrameError::ComputeError(
-                    format!("Merging arrays not yet implemented for {:?}", t),
-                ))
-            }
-            // DataType::LargeBinary => {
-            //     return Err(DataFrameError::ComputeError(
-            //         "Not yet implemented".to_string(),
-            //     ))
-            // }
-            // DataType::LargeUtf8 => {
-            //     return Err(DataFrameError::ComputeError(
-            //         "Not yet implemented".to_string(),
-            //     ))
-            // }
-            // DataType::LargeList(_) => {
-            //     return Err(DataFrameError::ComputeError(
-            //         "Not yet implemented".to_string(),
-            //     ))
-            // }
+            } // t => {
+              //     return Err(DataFrameError::ComputeError(
+              //         format!("Merging arrays not yet implemented for {:?}", t),
+              //     ))
+              // }
+              // DataType::LargeBinary => {
+              //     return Err(DataFrameError::ComputeError(
+              //         "Not yet implemented".to_string(),
+              //     ))
+              // }
+              // DataType::LargeUtf8 => {
+              //     return Err(DataFrameError::ComputeError(
+              //         "Not yet implemented".to_string(),
+              //     ))
+              // }
+              // DataType::LargeList(_) => {
+              //     return Err(DataFrameError::ComputeError(
+              //         "Not yet implemented".to_string(),
+              //     ))
+              // }
         }
     }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -262,21 +262,26 @@ impl Column {
                     "Not yet implemented".to_string(),
                 ))
             }
-            DataType::LargeBinary => {
+            t => {
                 return Err(DataFrameError::ComputeError(
-                    "Not yet implemented".to_string(),
+                    format!("Merging arrays not yet implemented for {:?}", t),
                 ))
             }
-            DataType::LargeUtf8 => {
-                return Err(DataFrameError::ComputeError(
-                    "Not yet implemented".to_string(),
-                ))
-            }
-            DataType::LargeList(_) => {
-                return Err(DataFrameError::ComputeError(
-                    "Not yet implemented".to_string(),
-                ))
-            }
+            // DataType::LargeBinary => {
+            //     return Err(DataFrameError::ComputeError(
+            //         "Not yet implemented".to_string(),
+            //     ))
+            // }
+            // DataType::LargeUtf8 => {
+            //     return Err(DataFrameError::ComputeError(
+            //         "Not yet implemented".to_string(),
+            //     ))
+            // }
+            // DataType::LargeList(_) => {
+            //     return Err(DataFrameError::ComputeError(
+            //         "Not yet implemented".to_string(),
+            //     ))
+            // }
         }
     }
 


### PR DESCRIPTION
Adds inital sorting support, currently limited to Arrow's `ArrowNumericType`. More sort types are pending upstream work (floats, lists, structs, etc).

Closes #16 